### PR TITLE
Use source instead of bash to prevent issues on more environments

### DIFF
--- a/src/Commands/Build.php
+++ b/src/Commands/Build.php
@@ -101,11 +101,11 @@ class Build extends Command {
 		$this->output->writeln( '<fg=cyan>* Running npm install</>', OutputInterface::VERBOSITY_VERBOSE );
 
 		$pool->add( new Process( 'composer dump-autoload && composer install' ), [ 'composer' ] );
-		$pool->add( new Process( 'bash ' . $this->get_nvm_path() . ' && nvm use && npm install && npm update product-taskmaster' ), [ 'npm' ] );
+		$pool->add( new Process( 'source ' . $this->get_nvm_path() . ' && nvm use && npm install && npm update product-taskmaster' ), [ 'npm' ] );
 
 		if ( $this->has_common ) {
 			$pool->add( new Process( 'cd common && composer dump-autoload && composer install' ), [ 'composer common' ] );
-			$pool->add( new Process( 'cd common && bash ' . $this->get_nvm_path() . ' && nvm use && npm install && npm update product-taskmaster' ), [ 'npm common' ] );
+			$pool->add( new Process( 'cd common && source ' . $this->get_nvm_path() . ' && nvm use && npm install && npm update product-taskmaster' ), [ 'npm common' ] );
 		}
 
 		$lines = new Lines( $this->output, $pool );
@@ -115,10 +115,10 @@ class Build extends Command {
 
 		$pool = new Pool();
 
-		$pool->add( new Process( 'bash ' . $this->get_nvm_path() . ' && nvm use && gulp' ), [ 'gulp' ] );
+		$pool->add( new Process( 'source ' . $this->get_nvm_path() . ' && nvm use && gulp' ), [ 'gulp' ] );
 
 		if ( $this->has_common ) {
-			$pool->add( new Process( 'cd common && bash ' . $this->get_nvm_path() . ' && nvm use && gulp' ), [ 'gulp common' ] );
+			$pool->add( new Process( 'cd common && source ' . $this->get_nvm_path() . ' && nvm use && gulp' ), [ 'gulp common' ] );
 		}
 
 		$lines = new Lines( $this->output, $pool );
@@ -127,7 +127,7 @@ class Build extends Command {
 		if ( file_exists( 'webpack.config.js' ) ) {
 			$this->output->writeln( '<fg=cyan>* Gulp Webpack</>', OutputInterface::VERBOSITY_VERBOSE );
 			// gulp webpack with a timeout of 15 minutes
-			$this->run_process( 'bash ' . $this->get_nvm_path() . ' && nvm use && gulp webpack', true, 900 );
+			$this->run_process( 'source ' . $this->get_nvm_path() . ' && nvm use && gulp webpack', true, 900 );
 		}
 	}
 }


### PR DESCRIPTION
More details about the issue here:
https://lw.slack.com/archives/G01H7Q57P1C/p1609432590051800

Error this prevents:

```
Error Output:
================
sh: nvm: command not found
The command "cd common && bash /Users/sc0ttkclark/.nvm/nvm.sh && nvm use && gulp" failed.
Exit Code: 127(Command not found)
Working directory: /Users/sc0ttkclark/Dropbox/Local Sites/test.tribe.local/app/public/wp-content/plugins/event-tickets
```

To be further discussed on whether this fix is necessary or if `bash` usage was supposed to solve something else.