### PR TITLE
update npm install to npm ci, remove updating product taskmaster

### DIFF
--- a/src/Commands/Build.php
+++ b/src/Commands/Build.php
@@ -126,11 +126,11 @@ class Build extends Command {
 		$this->output->writeln( '<fg=cyan>* Running npm install</>', OutputInterface::VERBOSITY_VERBOSE );
 
 		$pool->add( new Process( 'composer dump-autoload && composer install' ), [ 'composer' ] );
-		$pool->add( new Process( $this->get_source_command() . ' ' . $this->get_nvm_path() . ' && nvm use && npm install && npm update product-taskmaster' ), [ 'npm' ] );
+		$pool->add( new Process( $this->get_source_command() . ' ' . $this->get_nvm_path() . ' && nvm use && npm ci' ), [ 'npm' ] );
 
 		if ( $this->has_common ) {
 			$pool->add( new Process( 'cd common && composer dump-autoload && composer install' ), [ 'composer common' ] );
-			$pool->add( new Process( 'cd common && ' . $this->get_source_command() . ' ' . $this->get_nvm_path() . ' && nvm use && npm install && npm update product-taskmaster' ), [ 'npm common' ] );
+			$pool->add( new Process( 'cd common && ' . $this->get_source_command() . ' ' . $this->get_nvm_path() . ' && nvm use && npm ci' ), [ 'npm common' ] );
 		}
 
 		$lines = new Lines( $this->output, $pool );

--- a/src/Commands/Package.php
+++ b/src/Commands/Package.php
@@ -740,10 +740,10 @@ class Package extends Command {
 		$this->run_process( $this->get_source_command() . ' ' . $this->get_nvm_path() . ' && nvm install $(cat .nvmrc)' );
 
 		$pool = new Pool();
-		$pool->add( new Process( $this->get_source_command() . ' ' . $this->get_nvm_path() . ' && nvm use && npm ci && npm update product-taskmaster --no-save' ), [ 'npm' ] );
+		$pool->add( new Process( $this->get_source_command() . ' ' . $this->get_nvm_path() . ' && nvm use && npm ci' ), [ 'npm' ] );
 
 		if ( $has_common ) {
-			$pool->add( new Process( 'cd common && ' . $this->get_source_command() . ' ' . $this->get_nvm_path() . ' && nvm use && npm ci && npm update product-taskmaster --no-save' ), [ 'npm common' ] );
+			$pool->add( new Process( 'cd common && ' . $this->get_source_command() . ' ' . $this->get_nvm_path() . ' && nvm use && npm ci' ), [ 'npm common' ] );
 		}
 
 		$composer_processes = $this->get_composer_processes( 'install', $plugin, '--no-dev' );


### PR DESCRIPTION
**Ticket:** N/A

This PR updates npm install to npm ci and removes updating product taskmaster.
With moving `product-taskmaster` from the github source to npm, there would be no need to update product taskmaster as the `package-lock.json` should have the correct version. We should merge this in first before merging in the work to install product taskmaster from npm.

**Artifact:** TBD