### PR TITLE
Create `svn:tag` command.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.8] - 2023-07-12
+
+- Enhancement: Add `svn:tag` command to create a new SVN tag for a plugin.
+
+## [1.2.7] - 2022-03-22
+
+- Enhancement: Create extensions as `tec-labs-` rather than `tribe-ext-`
+
 ## [1.2.6] - 2021-06-03
 ### Updated
 

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
+    "php": "7.4",
     "symfony/console": "^3.1",
     "symfony/process": "^3.1",
     "maciejczyzewski/bottomline": "*",

--- a/src/Commands/SvnTag.php
+++ b/src/Commands/SvnTag.php
@@ -9,229 +9,228 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SvnTag extends Command {
-    protected const CMD_SUCCESS = 0;
+	protected const CMD_SUCCESS = 0;
 
-    protected const CMD_FAILURE = 1;
+	protected const CMD_FAILURE = 1;
 
-    protected const WP_ORG_URL =  'https://plugins.svn.wordpress.org/';
+	protected const WP_ORG_URL = 'https://plugins.svn.wordpress.org/';
 
-    protected function configure() {
-        $temp_dir = '/tmp/svn-tag/';
+	protected function configure() {
+		$temp_dir = '/tmp/svn-tag/';
 
-        $this
-            ->setName('svn:tag')
-            ->setDescription('Creates a new SVN tag and applies changes from a ZIP file.')
-            ->setHelp(  'This command allows you to create a new SVN tag from an existing tag and apply changes from a ZIP file.')
-            ->addArgument( 'plugin', InputArgument::REQUIRED, 'The URL of the SVN repository.' )
-            ->addArgument( 'source_tag', InputArgument::REQUIRED, 'The SVN tag to be copied.' )
-            ->addArgument( 'destination_tag', InputArgument::REQUIRED, 'The new SVN tag.' )
-            ->addOption( 'zip_url', 'z', InputOption::VALUE_OPTIONAL, 'The URL of the ZIP file with changes to apply.' )
-            ->addOption( 'temp_dir', 't', InputOption::VALUE_OPTIONAL, 'The temporary directory to use.', $temp_dir );
-    }
+		$this
+			->setName( 'svn:tag' )
+			->setDescription( 'Creates a new SVN tag and applies changes from a ZIP file.' )
+			->setHelp( 'This command allows you to create a new SVN tag from an existing tag and apply changes from a ZIP file.' )
+			->addArgument( 'plugin', InputArgument::REQUIRED, 'The URL of the SVN repository.' )
+			->addArgument( 'source_tag', InputArgument::REQUIRED, 'The SVN tag to be copied.' )
+			->addArgument( 'destination_tag', InputArgument::REQUIRED, 'The new SVN tag.' )
+			->addOption( 'zip_url', 'z', InputOption::VALUE_OPTIONAL, 'The URL of the ZIP file with changes to apply.' )
+			->addOption( 'temp_dir', 't', InputOption::VALUE_OPTIONAL, 'The temporary directory to use.', $temp_dir );
+	}
 
-    protected function execute( InputInterface $input, OutputInterface $output ) {
-        @ini_set( 'memory_limit', '2048M' );
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+		@ini_set( 'memory_limit', '2048M' );
 
-        $id = date( 'Y-m-d-H-m-s' ) . '-' .  substr( uniqid(), 0, 12 );
-        $plugin = $input->getArgument( 'plugin' );
-        $source_tag = $input->getArgument( 'source_tag' );
-        $destination_tag = $input->getArgument( 'destination_tag' );
-        $zip_url = $input->getOption( 'zip_url' );
-        $temp_dir = $input->getOption( 'temp_dir' );
+		$id              = date( 'Y-m-d-H-m-s' ) . '-' . substr( uniqid(), 0, 12 );
+		$plugin          = $input->getArgument( 'plugin' );
+		$source_tag      = $input->getArgument( 'source_tag' );
+		$destination_tag = $input->getArgument( 'destination_tag' );
+		$zip_url         = $input->getOption( 'zip_url' );
+		$temp_dir        = $input->getOption( 'temp_dir' );
 
-        $temp_dir = rtrim( $temp_dir, '/' ) . "/tag-{$id}";
+		$temp_dir = rtrim( $temp_dir, '/' ) . "/tag-{$id}";
 
-        if ( empty( $local_repo ) ) {
-            $local_repo = "{$temp_dir}/repo";
-        }
-        $svn_url = self::WP_ORG_URL . $plugin;
+		if ( empty( $local_repo ) ) {
+			$local_repo = "{$temp_dir}/repo";
+		}
+		$svn_url = self::WP_ORG_URL . $plugin;
 
-        // Log the arguments and options
-        $output->writeln( 'Plugin: ' . $plugin );
-        $output->writeln( 'SVN URL: ' . $svn_url );
-        $output->writeln( 'Source Tag: ' . $source_tag );
-        $output->writeln( 'Destination Tag: ' . $destination_tag );
-        $output->writeln( 'ZIP URL: ' . $zip_url );
-        $output->writeln( 'Temporary Directory: ' . $temp_dir );
+		// Log the arguments and options
+		$output->writeln( 'Plugin: ' . $plugin );
+		$output->writeln( 'SVN URL: ' . $svn_url );
+		$output->writeln( 'Source Tag: ' . $source_tag );
+		$output->writeln( 'Destination Tag: ' . $destination_tag );
+		$output->writeln( 'ZIP URL: ' . $zip_url );
+		$output->writeln( 'Temporary Directory: ' . $temp_dir );
 
-        $plugin_dir = $temp_dir . '/plugin/';
+		$plugin_dir = $temp_dir . '/plugin/';
 
-        // Create temporary directory if it doesn't exist
-        if ( ! is_dir( $temp_dir ) ) {
-            $output->writeln( 'Temporary directory does not exist. Creating: ' . $temp_dir );
-            mkdir( $temp_dir, 0755, true );
-        }
+		// Create temporary directory if it doesn't exist
+		if ( ! is_dir( $temp_dir ) ) {
+			$output->writeln( 'Temporary directory does not exist. Creating: ' . $temp_dir );
+			mkdir( $temp_dir, 0755, true );
+		}
 
-        // Ensure the plugin extraction dir is empty before doing anything.
-        if ( file_exists( $plugin_dir ) ) {
-            shell_exec( "rm -rf {$plugin_dir}" );
-            mkdir( $plugin_dir, 0755, true );
-        }
+		// Ensure the plugin extraction dir is empty before doing anything.
+		if ( file_exists( $plugin_dir ) ) {
+			shell_exec( "rm -rf {$plugin_dir}" );
+			mkdir( $plugin_dir, 0755, true );
+		}
 
-        // Download and extract ZIP file to temporary directory
-        $zip_file = rtrim( $temp_dir, '/' ) . '/plugin.zip';
+		// Download and extract ZIP file to temporary directory
+		$zip_file = rtrim( $temp_dir, '/' ) . '/plugin.zip';
 
-        // just to make sure we can download the new file.
-        if ( file_exists( $zip_file ) && is_file( $zip_file ) ) {
-            unlink( $zip_file );
-        }
+		// just to make sure we can download the new file.
+		if ( file_exists( $zip_file ) && is_file( $zip_file ) ) {
+			unlink( $zip_file );
+		}
 
-        $output->writeln( 'Downloading ZIP file to: ' . $zip_file );
+		$output->writeln( 'Downloading ZIP file to: ' . $zip_file );
 
-        file_put_contents( $zip_file, file_get_contents( $zip_url ) );
-        $output->writeln( 'Extracting ZIP file to: ' . $temp_dir );
-        $zip = new \ZipArchive();
+		file_put_contents( $zip_file, file_get_contents( $zip_url ) );
+		$output->writeln( 'Extracting ZIP file to: ' . $temp_dir );
+		$zip = new \ZipArchive();
 
-        if ( $zip->open( $zip_file ) === TRUE ) {
-            $zip->extractTo( $temp_dir );
-            $zip->close();
+		if ( $zip->open( $zip_file ) === true ) {
+			$zip->extractTo( $temp_dir );
+			$zip->close();
 
-            shell_exec( "mv {$temp_dir}/{$plugin} $plugin_dir" );
-            if ( ! file_exists( $plugin_dir ) ) {
-                $output->writeln( "<error>ZIP was not extracted correctly, expected destination: {$plugin_dir}.</error>" );
-            }
-        } else {
-            $output->writeln( '<error>Failed to open ZIP file.</error>' );
-            return self::CMD_FAILURE;
-        }
+			shell_exec( "mv {$temp_dir}/{$plugin} $plugin_dir" );
+			if ( ! file_exists( $plugin_dir ) ) {
+				$output->writeln( "<error>ZIP was not extracted correctly, expected destination: {$plugin_dir}.</error>" );
+			}
+		} else {
+			$output->writeln( '<error>Failed to open ZIP file.</error>' );
+			return self::CMD_FAILURE;
+		}
 
-        $cd_to_repo_cmd = "cd {$local_repo} && ";
+		$cd_to_repo_cmd = "cd {$local_repo} && ";
 
-        $clone_cmd = "svn co {$svn_url} {$local_repo} --depth=immediates";
-        $output->writeln( "Executing SVN Command: \n" . $clone_cmd );
-        shell_exec( $clone_cmd );
+		$clone_cmd = "svn co {$svn_url} {$local_repo} --depth=immediates";
+		$output->writeln( "Executing SVN Command: \n" . $clone_cmd );
+		shell_exec( $clone_cmd );
 
-        $update_trunk_cmd = "svn update trunk/readme.txt";
-        $output->writeln( "Executing SVN Command: \n" . $update_trunk_cmd );
-        shell_exec( $cd_to_repo_cmd . $update_trunk_cmd );
+		$update_trunk_cmd = "svn update trunk/readme.txt";
+		$output->writeln( "Executing SVN Command: \n" . $update_trunk_cmd );
+		shell_exec( $cd_to_repo_cmd . $update_trunk_cmd );
 
+		$update_tag_trunk_cmd = "svn update tags/{$source_tag}";
+		$output->writeln( "Executing SVN Command: \n" . $update_tag_trunk_cmd );
+		shell_exec( $cd_to_repo_cmd . $update_tag_trunk_cmd );
 
-        $update_tag_trunk_cmd = "svn update tags/{$source_tag}";
-        $output->writeln( "Executing SVN Command: \n" . $update_tag_trunk_cmd );
-        shell_exec( $cd_to_repo_cmd . $update_tag_trunk_cmd );
+		// Copy SVN tag
+		$copy_cmd = "svn copy {$svn_url}/tags/{$source_tag} {$svn_url}/tags/{$destination_tag} -m 'Copying {$source_tag} into {$destination_tag}'";
+		$output->writeln( "Executing SVN Command:  \n" . $copy_cmd );
+		shell_exec( $copy_cmd );
 
-        // Copy SVN tag
-        $copy_cmd = "svn copy {$svn_url}/tags/{$source_tag} {$svn_url}/tags/{$destination_tag} -m 'Copying {$source_tag} into {$destination_tag}'";
-        $output->writeln( "Executing SVN Command:  \n" . $copy_cmd );
-        shell_exec( $copy_cmd );
+		// Update local repository
+		$update_cmd = "svn update tags/{$destination_tag}";
+		$output->writeln( "Executing SVN Command: \n" . $update_cmd );
+		shell_exec( $cd_to_repo_cmd . $update_cmd );
 
-        // Update local repository
-        $update_cmd = "svn update tags/{$destination_tag}";
-        $output->writeln( "Executing SVN Command: \n" . $update_cmd );
-        shell_exec( $cd_to_repo_cmd . $update_cmd );
+		// Compare tag folder and extracted folder
+		$source_tag_folder      = "{$local_repo}/tags/{$source_tag}";
+		$destination_tag_folder = "{$local_repo}/tags/{$destination_tag}";
 
-        // Compare tag folder and extracted folder
-        $source_tag_folder = "{$local_repo}/tags/{$source_tag}";
-        $destination_tag_folder = "{$local_repo}/tags/{$destination_tag}";
+		// Delete tag folder
+		$delete_cmd = "rm -rf {$destination_tag_folder}";
+		$output->writeln( "Removing locally the destination tag: \n" . $delete_cmd );
+		shell_exec( $delete_cmd );
 
-        // Delete tag folder
-        $delete_cmd = "rm -rf {$destination_tag_folder}";
-        $output->writeln( "Removing locally the destination tag: \n" . $delete_cmd );
-        shell_exec( $delete_cmd );
+		// Move extracted files to tag folder
+		$move_cmd = "mv {$plugin_dir} {$destination_tag_folder}";
+		$output->writeln( "Move the ZIP version of the destination tag to the correct folder: \n" . $move_cmd );
+		shell_exec( $move_cmd );
 
-        // Move extracted files to tag folder
-        $move_cmd = "mv {$plugin_dir} {$destination_tag_folder}";
-        $output->writeln( "Move the ZIP version of the destination tag to the correct folder: \n" . $move_cmd );
-        shell_exec( $move_cmd );
+		$scan = $this->compare_directories( $source_tag_folder, $destination_tag_folder );
 
-        $scan = $this->compare_directories( $source_tag_folder, $destination_tag_folder );
+		$output->writeln( "Comparing Directories:" );
+		$output->writeln( " - $source_tag_folder" );
+		$output->writeln( " - $destination_tag_folder" );
 
-        $output->writeln( "Comparing Directories:" );
-        $output->writeln( " - $source_tag_folder" );
-        $output->writeln( " - $destination_tag_folder" );
+		if ( null === $scan ) {
+			$output->writeln( '<error>Error while trying to compare folders.</error>' );
+			return self::CMD_FAILURE;
+		}
 
-        if ( null === $scan ) {
-            $output->writeln('<error>Error while trying to compare folders.</error>');
-            return self::CMD_FAILURE;
-        }
-
-        if ( ! empty( $scan['added'] ) ) {
+		if ( ! empty( $scan['added'] ) ) {
 			$output->writeln( '' );
 
-            $output->writeln( "Added files: \n - " . implode( "\n - ", $scan['added'] ) );
-
-			$output->writeln( '' );
-
-            $output->writeln( "Including all added files from destination Tag folder: " );
-            foreach ( $scan['added'] as $file ) {
-                $add_cmd = "svn add --parents tags/{$destination_tag}/{$file}";
-                $output->writeln( $add_cmd );
-                shell_exec( $cd_to_repo_cmd . $add_cmd );
-            }
-        }
-
-        if ( ! empty( $scan['deleted'] ) ) {
-			$output->writeln( '' );
-
-            $output->writeln( "Deleted files: \n - " . implode( "\n - ", $scan['deleted'] ) );
+			$output->writeln( "Added files: \n - " . implode( "\n - ", $scan['added'] ) );
 
 			$output->writeln( '' );
 
-            // Remove deleted files
-            $output->writeln( "Deleting all removed files from destination Tag folder:" );
-            foreach ( $scan['deleted'] as $file ) {
-                $remove_cmd = "svn rm tags/{$destination_tag}/{$file}";
-                $output->writeln( $remove_cmd );
-                shell_exec( $cd_to_repo_cmd . $remove_cmd );
-            }
-        }
+			$output->writeln( "Including all added files from destination Tag folder: " );
+			foreach ( $scan['added'] as $file ) {
+				$add_cmd = "svn add --parents tags/{$destination_tag}/{$file}";
+				$output->writeln( $add_cmd );
+				shell_exec( $cd_to_repo_cmd . $add_cmd );
+			}
+		}
+
+		if ( ! empty( $scan['deleted'] ) ) {
+			$output->writeln( '' );
+
+			$output->writeln( "Deleted files: \n - " . implode( "\n - ", $scan['deleted'] ) );
+
+			$output->writeln( '' );
+
+			// Remove deleted files
+			$output->writeln( "Deleting all removed files from destination Tag folder:" );
+			foreach ( $scan['deleted'] as $file ) {
+				$remove_cmd = "svn rm tags/{$destination_tag}/{$file}";
+				$output->writeln( $remove_cmd );
+				shell_exec( $cd_to_repo_cmd . $remove_cmd );
+			}
+		}
 
 		$output->writeln( '' );
 
-        // Commit changes
-        $commit_cmd = "svn commit tags/{$destination_tag} -m 'Apply modifications to {$destination_tag}'";
-        $output->writeln( "Executing SVN Command:  \n" . $commit_cmd );
-        shell_exec( $cd_to_repo_cmd . $commit_cmd );
+		// Commit changes
+		$commit_cmd = "svn commit tags/{$destination_tag} -m 'Apply modifications to {$destination_tag}'";
+		$output->writeln( "Executing SVN Command:  \n" . $commit_cmd );
+		shell_exec( $cd_to_repo_cmd . $commit_cmd );
 
-        /**
-         * The check sum below doesnt work, need some more work before its ready.
-         *
-        $svn_checksum = shell_exec( "svn info --show-item=checksum {$svn_url}/tags/{$destination_tag}" );
-        $zip_checksum = sha1_file( $zip_file );
+		/**
+		 * The check sum below doesnt work, need some more work before its ready.
+		 *
+		 * $svn_checksum = shell_exec( "svn info --show-item=checksum {$svn_url}/tags/{$destination_tag}" );
+		 * $zip_checksum = sha1_file( $zip_file );
+		 *
+		 * if ($svn_checksum !== $zip_checksum) {
+		 * $output->writeln('<error>Checksum mismatch.</error>');
+		 * return self::CMD_FAILURE;
+		 * }
+		 */
 
-        if ($svn_checksum !== $zip_checksum) {
-            $output->writeln('<error>Checksum mismatch.</error>');
-            return self::CMD_FAILURE;
-        }
-         */
+		$output->writeln( '<success>Operation completed successfully.</success>' );
 
-        $output->writeln('<success>Operation completed successfully.</success>');
+		$output->writeln( 'Deleting temporary files to cleanup workspace.' );
+		shell_exec( "rm -rf {$temp_dir}" );
 
-        $output->writeln('Deleting temporary files to cleanup workspace.');
-        shell_exec( "rm -rf {$temp_dir}" );
+		return self::CMD_SUCCESS;
+	}
 
-        return self::CMD_SUCCESS;
-    }
+	/**
+	 * Compare two directories and return an array of added and deleted files.
+	 *
+	 * @param string $source      Directory A.
+	 * @param string $destination Directory B.
+	 *
+	 * @return array|null
+	 */
+	public function compare_directories( $source, $destination ) {
+		// Ensure directories end with '/'
+		$source      = rtrim( $source, '/' ) . '/';
+		$destination = rtrim( $destination, '/' ) . '/';
 
-    /**
-     * Compare two directories and return an array of added and deleted files.
-     *
-     * @param string $source  Directory A.
-     * @param string $destination  Directory B.
-     *
-     * @return array|null
-     */
-    public function compare_directories( $source, $destination ) {
-        // Ensure directories end with '/'
-        $source = rtrim( $source, '/' ) . '/';
-        $destination = rtrim( $destination, '/' ) . '/';
+		// Check if directories exist
+		if ( ! is_dir( $source ) || ! is_dir( $destination ) ) {
+			return null;
+		}
 
-        // Check if directories exist
-        if ( ! is_dir( $source ) || ! is_dir( $destination ) ) {
-            return null;
-        }
+		// Execute rsync command to check for added files.
+		$command = "rsync --dry-run --itemize-changes --recursive --ignore-existing {$destination}/ {$source}/ | grep '>f+' | awk '{print \$2}'";
+		exec( $command, $added_in_source );
 
-        // Execute rsync command to check for added files.
-        $command = "rsync --dry-run --itemize-changes --recursive --ignore-existing {$destination}/ {$source}/ | grep '>f+' | awk '{print \$2}'";
-        exec( $command, $added_in_source );
+		// Execute rsync command to check for deleted files.
+		$command = "rsync --dry-run --itemize-changes --recursive --ignore-existing {$source}/ {$destination}/ | grep '>f+' | awk '{print \$2}'";
+		exec( $command, $removed_from_source );
 
-        // Execute rsync command to check for deleted files.
-        $command = "rsync --dry-run --itemize-changes --recursive --ignore-existing {$source}/ {$destination}/ | grep '>f+' | awk '{print \$2}'";
-        exec( $command, $removed_from_source );
-
-        return [
-            'deleted' => array_values( $removed_from_source ),  // Re-index the array
-            'added'   => array_values( $added_in_source ),    // Re-index the array
-        ];
-    }
+		return [
+			'deleted' => array_values( $removed_from_source ),  // Re-index the array
+			'added' => array_values( $added_in_source ),    // Re-index the array
+		];
+	}
 }

--- a/src/Commands/SvnTag.php
+++ b/src/Commands/SvnTag.php
@@ -9,11 +9,67 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SvnTag extends Command {
+	/**
+	 * Stores the input interface.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @var InputInterface|null
+	 */
 	protected ?InputInterface $input;
+
+	/**
+	 * Stores the output interface.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @var OutputInterface|null
+	 */
 	protected ?OutputInterface $output;
+
+	/**
+	 * Stores the command steps to cleanup.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @var array
+	 */
+	protected array $cleanup_steps = [];
+
+	/**
+	 * Stores the temporary directory to use.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @var string|null
+	 */
 	protected ?string $temp_dir;
+
+	/**
+	 * Stores the plugin slug.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @var string|null
+	 */
 	protected ?string $plugin_slug;
+
+	/**
+	 * Stores the source tag.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @var string|null
+	 */
 	protected ?string $source_tag;
+
+	/**
+	 * Stores the destination tag.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @var string|null
+	 */
 	protected ?string $destination_tag;
 
 	/**
@@ -57,54 +113,154 @@ class SvnTag extends Command {
 			->addOption( 'memory_limit', 'm', InputOption::VALUE_OPTIONAL, 'How much memory we clear for usage, since some of the operations can be expensive.', '512M' );
 	}
 
+	protected function has_cleanup_step( string $step ): bool {
+		return in_array( $step, $this->get_cleanup_steps(), true );
+	}
+
+	protected function get_cleanup_steps(): array {
+		return $this->cleanup_steps;
+	}
+
+	protected function include_cleanup_step( string $step ): void {
+		$allowed_steps = [
+			'remove_temp_dir',
+			'remove_remote_destination_tag',
+		];
+
+		if ( ! in_array( $step, $allowed_steps, true ) ) {
+			return;
+		}
+
+		$this->cleanup_steps[] = $step;
+	}
+
+	/**
+	 * Gets the input interface.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @return InputInterface The input interface.
+	 */
 	protected function get_input(): InputInterface {
 		return $this->input;
 	}
 
+	/**
+	 * Sets the input interface.
+	 *
+	 * @since 1.2.8
+	 */
 	protected function set_input( InputInterface $input ): void {
 		$this->input = $input;
 	}
 
+	/**
+	 * Sets the output interface.
+	 *
+	 * @since 1.2.8
+	 */
 	protected function set_output( OutputInterface $output ): void {
 		$this->output = $output;
 	}
 
+	/**
+	 * Gets the output interface.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @return OutputInterface The output interface.
+	 */
 	protected function get_output(): OutputInterface {
 		return $this->output;
 	}
 
+	/**
+	 * Sets the temporary directory.
+	 *
+	 * @since 1.2.8
+	 */
 	protected function set_temp_dir( string $dir ): void {
 		$this->temp_dir = $dir;
 	}
 
+	/**
+	 * Gets the temporary directory.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @return string The temporary directory.
+	 */
 	protected function get_temp_dir(): string {
 		return $this->temp_dir;
 	}
 
+	/**
+	 * Sets the plugin slug.
+	 *
+	 * @since 1.2.8
+	 */
 	protected function set_plugin_slug( string $plugin_slug ): void {
 		$this->plugin_slug = $plugin_slug;
 	}
 
+	/**
+	 * Gets the plugin slug.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @return string The plugin slug.
+	 */
 	protected function get_plugin_slug(): string {
 		return $this->plugin_slug;
 	}
 
+	/**
+	 *
+	 *
+	 * @since 1.2.8
+	 */
 	protected function set_destination_tag( string $tag ): void {
 		$this->destination_tag = $tag;
 	}
 
+	/**
+	 * Gets the destination tag.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @return string The destination tag.
+	 */
 	protected function get_destination_tag(): string {
 		return $this->destination_tag;
 	}
 
+	/**
+	 * Sets the source tag.
+	 *
+	 * @since 1.2.8
+	 */
 	protected function set_source_tag( string $tag ): void {
 		$this->source_tag = $tag;
 	}
 
+	/**
+	 * Gets the source tag.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @return string The source tag.
+	 */
 	protected function get_source_tag(): string {
 		return $this->source_tag;
 	}
 
+	/**
+	 * Gets the URL for the plugin on WordPress.org.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @return string The URL for the plugin on WordPress.org.
+	 */
 	protected function get_svn_url(): string {
 		return self::WP_ORG_URL . $this->get_plugin_slug();
 	}
@@ -132,11 +288,11 @@ class SvnTag extends Command {
 
 		$this->set_temp_dir( $temp_dir );
 		$this->set_source_tag( $source_tag );
-		$this->set_destination_tag( $plugin );
-		$this->set_plugin_slug( $destination_tag );
+		$this->set_destination_tag( $destination_tag );
+		$this->set_plugin_slug( $plugin );
 
 		$local_repo = "{$temp_dir}/repo";
-		$svn_url = self::WP_ORG_URL . $plugin;
+		$svn_url    = self::WP_ORG_URL . $plugin;
 
 		// Log the arguments and options
 		$output->writeln( 'Plugin: ' . $plugin );
@@ -163,6 +319,10 @@ class SvnTag extends Command {
 		if ( ! file_exists( $temp_dir ) ) {
 			return $this->cleanup_to_error( "Couldn't create the temporary directory, aborting." );
 		}
+
+		// From this moment forward we need to cleanup, so we catch an interrupt signal.
+		$this->catch_cli_exit_signals();
+		$this->include_cleanup_step( 'remove_temp_dir' );
 
 		// If the plugin extraction dir exists, delete it and recreate it.
 		if ( file_exists( $plugin_dir ) ) {
@@ -222,6 +382,8 @@ class SvnTag extends Command {
 		$output->writeln( "Executing SVN Command:  \n" . $copy_cmd );
 		shell_exec( $copy_cmd );
 
+		$this->include_cleanup_step( 'remove_remote_destination_tag' );
+
 		// Update local repository
 		$update_cmd = "svn update tags/{$destination_tag}";
 		$output->writeln( "Executing SVN Command: \n" . $update_cmd );
@@ -232,11 +394,11 @@ class SvnTag extends Command {
 		$destination_tag_folder = "{$local_repo}/tags/{$destination_tag}";
 
 		if ( ! file_exists( $source_tag_folder ) || ! is_dir( $source_tag_folder ) ) {
-			return $this->cleanup_to_error( "The source tag was not downloaded properly, aborting.", true );
+			return $this->cleanup_to_error( "The source tag was not downloaded properly, aborting." );
 		}
 
 		if ( ! file_exists( $destination_tag_folder ) || ! is_dir( $destination_tag_folder ) ) {
-			return $this->cleanup_to_error( "The destination tag was not downloaded properly, aborting.", true );
+			return $this->cleanup_to_error( "The destination tag was not downloaded properly, aborting." );
 		}
 
 		// Delete tag folder
@@ -256,7 +418,7 @@ class SvnTag extends Command {
 		$output->writeln( " - $destination_tag_folder" );
 
 		if ( null === $scan ) {
-			return $this->cleanup_to_error( "Error while trying to compare folders.", true );
+			return $this->cleanup_to_error( "Error while trying to compare folders." );
 		}
 
 		if ( ! empty( $scan['added'] ) ) {
@@ -346,18 +508,36 @@ class SvnTag extends Command {
 
 		return [
 			'deleted' => array_values( $removed_from_source ),  // Re-index the array
-			'added'   => array_values( $added_in_source ),    // Re-index the array
+			'added' => array_values( $added_in_source ),    // Re-index the array
 		];
 	}
 
-	protected function cleanup_to_error( string $message = null, bool $remote_destination_tag = false ): int {
+	/**
+	 * Cleanup the workspace and return error.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @param string|null $message
+	 *
+	 * @return int
+	 */
+	protected function cleanup_to_error( string $message = null ): int {
 
-		$this->cleanup( $remote_destination_tag );
+		$this->cleanup();
 
 		$this->get_output()->writeln( $message );
 		return self::CMD_FAILURE;
 	}
 
+	/**
+	 * Cleanup the workspace and return success.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @param string|null $message
+	 *
+	 * @return int
+	 */
 	protected function cleanup_to_success( string $message = null ): int {
 		$this->cleanup();
 
@@ -365,18 +545,53 @@ class SvnTag extends Command {
 		return self::CMD_SUCCESS;
 	}
 
-	protected function cleanup( bool $remote_destination_tag = false ) {
-		$temp_dir = $this->get_temp_dir();
+	/**
+	 * Cleanup the workspace.
+	 *
+	 * @since 1.2.8
+	 */
+	protected function cleanup() {
+		if ( $this->has_cleanup_step( 'remove_temp_dir' ) ) {
+			$temp_dir = $this->get_temp_dir();
 
-		$this->get_output()->writeln( 'Deleting temporary files to cleanup workspace.' );
-		shell_exec( "rm -rf {$temp_dir}" );
+			$this->get_output()->writeln( 'Deleting temporary files to cleanup workspace.' );
+			shell_exec( "rm -rf {$temp_dir}" );
+		}
 
-		if ( $remote_destination_tag ) {
-			$svn_url = $this->get_svn_url();
+		if ( $this->has_cleanup_step( 'remove_remote_destination_tag' ) ) {
+			$svn_url         = $this->get_svn_url();
 			$destination_tag = $this->get_destination_tag();
 
 			$this->get_output()->writeln( "Deleting remote tag '{$destination_tag}'." );
 			shell_exec( "svn rm {$svn_url}/tags/{$destination_tag} -m 'Delete remote tag {$destination_tag}.'" );
+		}
+	}
+
+	/**
+	 * Catch CLI exit signals.
+	 *
+	 * @since 1.2.8
+	 */
+	protected function catch_cli_exit_signals(): void {
+		pcntl_signal( SIGTERM, [ $this, 'cli_signal_handler' ] );
+		pcntl_signal( SIGINT, [ $this, 'cli_signal_handler' ] );
+	}
+
+	/**
+	 * Handle CLI exit signals.
+	 *
+	 * @since 1.2.8
+	 *
+	 * @param mixed $signal
+	 */
+	public function cli_signal_handler( $signal ) {
+		switch ( $signal ) {
+			case SIGTERM:
+			case SIGKILL:
+			case SIGINT:
+				$this->get_output()->writeln( "User interrupted the command, cleaning up required, please wait." );
+				$this->cleanup();
+				exit;
 		}
 	}
 }

--- a/src/Commands/SvnTag.php
+++ b/src/Commands/SvnTag.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace TUT\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SvnTag extends Command {
+    protected const CMD_SUCCESS = 0;
+
+    protected const CMD_FAILURE = 1;
+
+    protected const WP_ORG_URL =  'https://plugins.svn.wordpress.org/';
+
+    protected function configure() {
+        $temp_dir = '/tmp/svn-tag/';
+
+        $this
+            ->setName('svn:tag')
+            ->setDescription('Creates a new SVN tag and applies changes from a ZIP file.')
+            ->setHelp(  'This command allows you to create a new SVN tag from an existing tag and apply changes from a ZIP file.')
+            ->addArgument( 'plugin', InputArgument::REQUIRED, 'The URL of the SVN repository.' )
+            ->addArgument( 'source_tag', InputArgument::REQUIRED, 'The SVN tag to be copied.' )
+            ->addArgument( 'destination_tag', InputArgument::REQUIRED, 'The new SVN tag.' )
+            ->addOption( 'zip_url', 'z', InputOption::VALUE_OPTIONAL, 'The URL of the ZIP file with changes to apply.' )
+            ->addOption( 'temp_dir', 't', InputOption::VALUE_OPTIONAL, 'The temporary directory to use.', $temp_dir );
+    }
+
+    protected function execute( InputInterface $input, OutputInterface $output ) {
+        @ini_set( 'memory_limit', '2048M' );
+
+        $id = date( 'Y-m-d-H-m-s' ) . '-' .  substr( uniqid(), 0, 12 );
+        $plugin = $input->getArgument( 'plugin' );
+        $source_tag = $input->getArgument( 'source_tag' );
+        $destination_tag = $input->getArgument( 'destination_tag' );
+        $zip_url = $input->getOption( 'zip_url' );
+        $temp_dir = $input->getOption( 'temp_dir' );
+
+        $temp_dir = rtrim( $temp_dir, '/' ) . "/tag-{$id}";
+
+        if ( empty( $local_repo ) ) {
+            $local_repo = "{$temp_dir}/repo";
+        }
+        $svn_url = self::WP_ORG_URL . $plugin;
+
+        // Log the arguments and options
+        $output->writeln( 'Plugin: ' . $plugin );
+        $output->writeln( 'SVN URL: ' . $svn_url );
+        $output->writeln( 'Source Tag: ' . $source_tag );
+        $output->writeln( 'Destination Tag: ' . $destination_tag );
+        $output->writeln( 'ZIP URL: ' . $zip_url );
+        $output->writeln( 'Temporary Directory: ' . $temp_dir );
+
+        $plugin_dir = $temp_dir . '/plugin/';
+
+        // Create temporary directory if it doesn't exist
+        if ( ! is_dir( $temp_dir ) ) {
+            $output->writeln( 'Temporary directory does not exist. Creating: ' . $temp_dir );
+            mkdir( $temp_dir, 0755, true );
+        }
+
+        // Ensure the plugin extraction dir is empty before doing anything.
+        if ( file_exists( $plugin_dir ) ) {
+            shell_exec( "rm -rf {$plugin_dir}" );
+            mkdir( $plugin_dir, 0755, true );
+        }
+
+        // Download and extract ZIP file to temporary directory
+        $zip_file = rtrim( $temp_dir, '/' ) . '/plugin.zip';
+
+        // just to make sure we can download the new file.
+        if ( file_exists( $zip_file ) && is_file( $zip_file ) ) {
+            unlink( $zip_file );
+        }
+
+        $output->writeln( 'Downloading ZIP file to: ' . $zip_file );
+
+        file_put_contents( $zip_file, file_get_contents( $zip_url ) );
+        $output->writeln( 'Extracting ZIP file to: ' . $temp_dir );
+        $zip = new \ZipArchive();
+
+        if ( $zip->open( $zip_file ) === TRUE ) {
+            $zip->extractTo( $temp_dir );
+            $zip->close();
+
+            shell_exec( "mv {$temp_dir}/{$plugin} $plugin_dir" );
+            if ( ! file_exists( $plugin_dir ) ) {
+                $output->writeln( "<error>ZIP was not extracted correctly, expected destination: {$plugin_dir}.</error>" );
+            }
+        } else {
+            $output->writeln( '<error>Failed to open ZIP file.</error>' );
+            return self::CMD_FAILURE;
+        }
+
+        $cd_to_repo_cmd = "cd {$local_repo} && ";
+
+        $clone_cmd = "svn co {$svn_url} {$local_repo} --depth=immediates";
+        $output->writeln( "Executing SVN Command: \n" . $clone_cmd );
+        shell_exec( $clone_cmd );
+
+        $update_trunk_cmd = "svn update trunk/readme.txt";
+        $output->writeln( "Executing SVN Command: \n" . $update_trunk_cmd );
+        shell_exec( $cd_to_repo_cmd . $update_trunk_cmd );
+
+
+        $update_tag_trunk_cmd = "svn update tags/{$source_tag}";
+        $output->writeln( "Executing SVN Command: \n" . $update_tag_trunk_cmd );
+        shell_exec( $cd_to_repo_cmd . $update_tag_trunk_cmd );
+
+        // Copy SVN tag
+        $copy_cmd = "svn copy {$svn_url}/tags/{$source_tag} {$svn_url}/tags/{$destination_tag} -m 'Copying {$source_tag} into {$destination_tag}'";
+        $output->writeln( "Executing SVN Command:  \n" . $copy_cmd );
+        shell_exec( $copy_cmd );
+
+        // Update local repository
+        $update_cmd = "svn update tags/{$destination_tag}";
+        $output->writeln( "Executing SVN Command: \n" . $update_cmd );
+        shell_exec( $cd_to_repo_cmd . $update_cmd );
+
+        // Compare tag folder and extracted folder
+        $source_tag_folder = "{$local_repo}/tags/{$source_tag}";
+        $destination_tag_folder = "{$local_repo}/tags/{$destination_tag}";
+
+        // Delete tag folder
+        $delete_cmd = "rm -rf {$destination_tag_folder}";
+        $output->writeln( "Removing locally the destination tag: \n" . $delete_cmd );
+        shell_exec( $delete_cmd );
+
+        // Move extracted files to tag folder
+        $move_cmd = "mv {$plugin_dir} {$destination_tag_folder}";
+        $output->writeln( "Move the ZIP version of the destination tag to the correct folder: \n" . $move_cmd );
+        shell_exec( $move_cmd );
+
+        // Here we specifically invert, since we are using Rsync to test we are
+        // trying to copy the destination folder to the source folder in the comparison.
+        $scan = $this->compare_directories( $destination_tag_folder, $source_tag_folder );
+
+        $output->writeln( "Comparing Directories:" );
+        $output->writeln( " - $source_tag_folder" );
+        $output->writeln( " - $destination_tag_folder" );
+
+        if ( null === $scan ) {
+            $output->writeln('<error>Error while trying to compare folders.</error>');
+            return self::CMD_FAILURE;
+        }
+
+        if ( ! empty( $scan['added'] ) ) {
+            $output->writeln( "Added files: \n - " . implode( "\n - ", $scan['added'] ) );
+
+            $output->writeln( "Including all added files from destination Tag folder:  \n" );
+            foreach ( $scan['added'] as $file ) {
+                $add_cmd = "svn add tags/{$destination_tag}/{$file}";
+                $output->writeln( $add_cmd);
+                shell_exec( $cd_to_repo_cmd . $add_cmd );
+            }
+        }
+
+        if ( ! empty( $scan['deleted'] ) ) {
+            $output->writeln( "Deleted files: \n - " . implode( "\n - ", $scan['deleted'] ) );
+
+            // Remove deleted files
+            $output->writeln( "Deleting all removed files from destination Tag folder:  \n" );
+            foreach ( $scan['deleted'] as $file ) {
+                $remove_cmd = "svn rm tags/{$destination_tag}/{$file}";
+                $output->writeln( $remove_cmd );
+                shell_exec( $cd_to_repo_cmd . $remove_cmd );
+            }
+        }
+
+        // Commit changes
+        $commit_cmd = "svn commit tags/{$destination_tag} -m 'Apply modifications to {$destination_tag}'";
+        $output->writeln( "Executing SVN Command:  \n" . $commit_cmd );
+        shell_exec( $cd_to_repo_cmd . $commit_cmd );
+
+        /**
+         * The check sum below doesnt work, need some more work before its ready.
+         *
+        $svn_checksum = shell_exec( "svn info --show-item=checksum {$svn_url}/tags/{$destination_tag}" );
+        $zip_checksum = sha1_file( $zip_file );
+
+        if ($svn_checksum !== $zip_checksum) {
+            $output->writeln('<error>Checksum mismatch.</error>');
+            return self::CMD_FAILURE;
+        }
+         */
+
+        $output->writeln('<success>Operation completed successfully.</success>');
+
+        $output->writeln('Deleting temporary files to cleanup workspace.');
+        shell_exec( "rm -rf {$temp_dir}" );
+
+        return self::CMD_SUCCESS;
+    }
+
+    /**
+     * Compare two directories and return an array of added and deleted files.
+     *
+     * @param string $source  Directory A.
+     * @param string $destination  Directory B.
+     *
+     * @return array|null
+     */
+    public function compare_directories( $source, $destination ) {
+        // Ensure directories end with '/'
+        $source = rtrim( $source, '/' ) . '/';
+        $destination = rtrim( $destination, '/' ) . '/';
+
+        // Check if directories exist
+        if ( ! is_dir( $source ) || ! is_dir( $destination ) ) {
+            return null;
+        }
+
+        // Execute rsync command
+        $command = "rsync --dry-run --itemize-changes --recursive $source $destination | grep '^\\(.d.........\\|>f+++++++++\\)' | awk '{print $2}'";
+        exec( $command, $output );
+
+        // Separate added and deleted files
+        $added_files = array_filter( $output, function( $file ) use ( $destination ) {
+            return strpos( $file, $destination ) === 0;
+        });
+
+        $deleted_files = array_diff( $output, $added_files );
+
+        // Remove directory from file paths
+        $source = addcslashes( $source, ' ' ); // add slashes to spaces
+        $destination = addcslashes( $destination, ' ' ); // add slashes to spaces
+
+        $deleted_files = array_map(
+            function( $file ) use ( $source ) {
+                return str_replace( "$source", '', $file );
+            },
+            $deleted_files
+        );
+
+        $added_files   = array_map(
+            function( $file ) use ( $destination ) {
+                return str_replace( "$destination", '', $file );
+            },
+            $added_files
+        );
+
+        return [
+            'deleted' => array_values( $deleted_files ),  // Re-index the array
+            'added'   => array_values( $added_files ),    // Re-index the array
+        ];
+    }
+}

--- a/src/Commands/SvnTag.php
+++ b/src/Commands/SvnTag.php
@@ -134,9 +134,7 @@ class SvnTag extends Command {
         $output->writeln( "Move the ZIP version of the destination tag to the correct folder: \n" . $move_cmd );
         shell_exec( $move_cmd );
 
-        // Here we specifically invert, since we are using Rsync to test we are
-        // trying to copy the destination folder to the source folder in the comparison.
-        $scan = $this->compare_directories( $destination_tag_folder, $source_tag_folder );
+        $scan = $this->compare_directories( $source_tag_folder, $destination_tag_folder );
 
         $output->writeln( "Comparing Directories:" );
         $output->writeln( " - $source_tag_folder" );

--- a/src/Commands/SvnTag.php
+++ b/src/Commands/SvnTag.php
@@ -56,7 +56,7 @@ class SvnTag extends Command {
 	 * @since 1.2.8
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ) {
-		$memory_limit        = $input->getOption( 'memory_limit' );
+		$memory_limit = $input->getOption( 'memory_limit' );
 		@ini_set( 'memory_limit', $memory_limit );
 
 		$id              = date( 'Y-m-d-H-m-s' ) . '-' . substr( uniqid(), 0, 12 );
@@ -259,7 +259,7 @@ class SvnTag extends Command {
 
 		return [
 			'deleted' => array_values( $removed_from_source ),  // Re-index the array
-			'added' => array_values( $added_in_source ),    // Re-index the array
+			'added'   => array_values( $added_in_source ),    // Re-index the array
 		];
 	}
 }

--- a/src/Commands/SvnTag.php
+++ b/src/Commands/SvnTag.php
@@ -26,11 +26,13 @@ class SvnTag extends Command {
 			->addArgument( 'source_tag', InputArgument::REQUIRED, 'The SVN tag to be copied.' )
 			->addArgument( 'destination_tag', InputArgument::REQUIRED, 'The new SVN tag.' )
 			->addOption( 'zip_url', 'z', InputOption::VALUE_OPTIONAL, 'The URL of the ZIP file with changes to apply.' )
-			->addOption( 'temp_dir', 't', InputOption::VALUE_OPTIONAL, 'The temporary directory to use.', $temp_dir );
+			->addOption( 'temp_dir', 't', InputOption::VALUE_OPTIONAL, 'The temporary directory to use.', $temp_dir )
+			->addOption( 'memory_limit', 'm', InputOption::VALUE_OPTIONAL, 'How much memory we clear for usage, since some of the operations can be expensive.', '512M' );
 	}
 
 	protected function execute( InputInterface $input, OutputInterface $output ) {
-		@ini_set( 'memory_limit', '2048M' );
+		$memory_limit        = $input->getOption( 'memory_limit' );
+		@ini_set( 'memory_limit', $memory_limit );
 
 		$id              = date( 'Y-m-d-H-m-s' ) . '-' . substr( uniqid(), 0, 12 );
 		$plugin          = $input->getArgument( 'plugin' );

--- a/src/Commands/SvnTag.php
+++ b/src/Commands/SvnTag.php
@@ -9,12 +9,32 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SvnTag extends Command {
+	/**
+	 * @since 1.2.8
+	 *
+	 * @var int The exit code to use when the command succeeds.
+	 */
 	protected const CMD_SUCCESS = 0;
 
+	/**
+	 * @since 1.2.8
+	 *
+	 * @var int The exit code to use when the command fails.
+	 */
 	protected const CMD_FAILURE = 1;
 
+	/**
+	 * @since 1.2.8
+	 *
+	 * @var string Store the base URL for the WordPress.org SVN repository.
+	 */
 	protected const WP_ORG_URL = 'https://plugins.svn.wordpress.org/';
 
+	/**
+	 * Configures the command.
+	 *
+	 * @since 1.2.8
+	 */
 	protected function configure() {
 		$temp_dir = '/tmp/svn-tag/';
 
@@ -30,6 +50,11 @@ class SvnTag extends Command {
 			->addOption( 'memory_limit', 'm', InputOption::VALUE_OPTIONAL, 'How much memory we clear for usage, since some of the operations can be expensive.', '512M' );
 	}
 
+	/**
+	 * Executes the command.
+	 *
+	 * @since 1.2.8
+	 */
 	protected function execute( InputInterface $input, OutputInterface $output ) {
 		$memory_limit        = $input->getOption( 'memory_limit' );
 		@ini_set( 'memory_limit', $memory_limit );
@@ -206,6 +231,8 @@ class SvnTag extends Command {
 
 	/**
 	 * Compare two directories and return an array of added and deleted files.
+	 *
+	 * @since 1.2.8
 	 *
 	 * @param string $source      Directory A.
 	 * @param string $destination Directory B.

--- a/tut
+++ b/tut
@@ -4,7 +4,7 @@
 require dirname( __FILE__ ) . '/vendor/autoload.php';
 
 define( '__TUT_DIR__', __DIR__ );
-define( 'TUT_VERSION', '1.2.7' );
+define( 'TUT_VERSION', '1.2.8' );
 
 use Symfony\Component\Console\Application;
 use TUT\Commands;

--- a/tut
+++ b/tut
@@ -57,5 +57,6 @@ $application->add( new Commands\Sync );
 $application->add( new Commands\TBD );
 $application->add( new Commands\Version );
 $application->add( new Commands\Upgrade );
+$application->add( new Commands\SvnTag );
 
 $application->run();


### PR DESCRIPTION
This PR focuses on speeding up the process of creating a new Tag on WP.org, by copying the last tag remotely, which avoids a huge amount of processing on the WP.org end, which bring down the timing from 15ish minutes down to 3 minutes.

<img width="1266" alt="image" src="https://github.com/the-events-calendar/tut/assets/236579/841f7c87-2450-4c6a-b3cd-e6b15a679a70">
