### PR TITLE
Include svn:release command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ export PATH=/path/to/tut:$PATH
 
 ## SVN Subcommands
 
-| Command                               | Description                                  |
-|---------------------------------------|----------------------------------------------|
-| [`svn:tag`](docs/commands/svn/tag.md) | Create a tag on WordPress.org SVN repository |
+| Command                                       | Description                                   |
+|-----------------------------------------------|-----------------------------------------------|
+| [`svn:tag`](docs/commands/svn/tag.md)         | Create a tag on WordPress.org SVN repository  |
+| [`svn:release`](docs/commands/svn/release.md) | Release a tag on WordPress.org SVN repository |
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.10] - 2023-08-17
+## [1.2.10] - 2023-09-13
 
 - Enhancement: Add `svn:release` command to release a given SVN tag for a plugin.
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.9] - 2023-07-17
+
+- Enhancement: Add `svn:release` command to release a given SVN tag for a plugin.
+
 ## [1.2.8] - 2023-07-12
 
 - Enhancement: Add `svn:tag` command to create a new SVN tag for a plugin.

--- a/docs/commands/svn/release.md
+++ b/docs/commands/svn/release.md
@@ -1,4 +1,4 @@
-## `tut svn:tag`
+## `tut svn:release`
 
 **Release new versions on WP.org**
 

--- a/docs/commands/svn/release.md
+++ b/docs/commands/svn/release.md
@@ -1,0 +1,35 @@
+## `tut svn:tag`
+
+**Release new versions on WP.org**
+
+When dealing with WordPress.org SVN release it's time consuming to do a checksum of the tag you just created, this command aims to simplify the process by doing it for you before releasing.
+
+## Usage
+```
+  tut svn:release [options] [--] <plugin> <tag>
+```
+
+### Arguments:
+```
+  plugin                             The slug of the Plugin on WordPress.org.
+  tag                                The SVN tag to be released.
+```
+
+### Options:
+
+```
+  -c, --checksum_zip[=CHECKSUM_ZIP]  The URL of the ZIP file in case you want to do a Checksum.
+  -t, --temp_dir[=TEMP_DIR]          The temporary directory to use. [default: "/tmp/svn-tag/"]
+  -h, --help                         Display this help message
+  -q, --quiet                        Do not output any message
+  -V, --version                      Display this application version
+      --ansi                         Force ANSI output
+      --no-ansi                      Disable ANSI output
+  -n, --no-interaction               Do not ask any interactive question
+  -v|vv|vvv, --verbose               Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+```
+
+### Help:
+```
+  This command allows you to update what is the Stable Tag version of a WP.org plugin.
+ ```

--- a/src/Commands/SVN/Release.php
+++ b/src/Commands/SVN/Release.php
@@ -12,73 +12,84 @@ class Release extends Command {
 	/**
 	 * Stores the input interface.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @var InputInterface|null
 	 */
-	protected ?InputInterface $input;
+	protected $input;
 
 	/**
 	 * Stores the output interface.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @var OutputInterface|null
 	 */
-	protected ?OutputInterface $output;
+	protected $output;
 
 	/**
 	 * Stores the command steps to cleanup.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @var array
 	 */
-	protected array $cleanup_steps = [];
+	protected $cleanup_steps = [];
+
+	/**
+	 * Stores a list of allowed steps.
+	 *
+	 * @since 1.2.10
+	 *
+	 * @var array<string>
+	 */
+	protected $allowed_steps = [
+		'remove_temp_dir',
+	];
 
 	/**
 	 * Stores the temporary directory to use.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @var string|null
 	 */
-	protected ?string $temp_dir;
+	protected $temp_dir;
 
 	/**
 	 * Stores the plugin slug.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @var string|null
 	 */
-	protected ?string $plugin_slug;
+	protected $plugin_slug;
 
 	/**
 	 * Stores the destination tag.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @var string|null
 	 */
-	protected ?string $tag;
+	protected $tag;
 
 	/**
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @var int The exit code to use when the command succeeds.
 	 */
 	protected const CMD_SUCCESS = 0;
 
 	/**
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @var int The exit code to use when the command fails.
 	 */
 	protected const CMD_FAILURE = 1;
 
 	/**
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @var string Store the base URL for the WordPress.org SVN repository.
 	 */
@@ -87,7 +98,7 @@ class Release extends Command {
 	/**
 	 * Configures the command.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 */
 	protected function configure() {
 		$temp_dir = '/tmp/svn-tag/';
@@ -110,12 +121,15 @@ class Release extends Command {
 		return $this->cleanup_steps;
 	}
 
+	/**
+	 * Includes a cleanup step, if it's an allowed step.
+	 *
+	 * @since 1.2.10
+	 *
+	 * @param string $step
+	 */
 	protected function include_cleanup_step( string $step ): void {
-		$allowed_steps = [
-			'remove_temp_dir',
-		];
-
-		if ( ! in_array( $step, $allowed_steps, true ) ) {
+		if ( ! in_array( $step, $this->allowed_steps, true ) ) {
 			return;
 		}
 
@@ -123,9 +137,34 @@ class Release extends Command {
 	}
 
 	/**
+	 * Removes a cleanup step, if it's an allowed step.
+	 *
+	 * @since 1.2.10
+	 *
+	 * @param string $step
+	 */
+	protected function remove_cleanup_step( string $step ): void {
+		if ( ! in_array( $step, $this->allowed_steps, true ) ) {
+			return;
+		}
+
+		$index = array_search( $step, $this->cleanup_steps, true );
+
+		// Bail if the step is not in the array.
+		if ( ! isset( $this->cleanup_steps[ $index ] ) ) {
+			return;
+		}
+
+		unset( $this->cleanup_steps[ $index ] );
+
+		// Reindex the array.
+		$this->cleanup_steps = array_values( $this->cleanup_steps );
+	}
+
+	/**
 	 * Gets the input interface.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @return InputInterface The input interface.
 	 */
@@ -136,7 +175,7 @@ class Release extends Command {
 	/**
 	 * Sets the input interface.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 */
 	protected function set_input( InputInterface $input ): void {
 		$this->input = $input;
@@ -145,7 +184,7 @@ class Release extends Command {
 	/**
 	 * Sets the output interface.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 */
 	protected function set_output( OutputInterface $output ): void {
 		$this->output = $output;
@@ -154,7 +193,7 @@ class Release extends Command {
 	/**
 	 * Gets the output interface.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @return OutputInterface The output interface.
 	 */
@@ -165,7 +204,7 @@ class Release extends Command {
 	/**
 	 * Sets the temporary directory.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 */
 	protected function set_temp_dir( string $dir ): void {
 		$this->temp_dir = $dir;
@@ -174,7 +213,7 @@ class Release extends Command {
 	/**
 	 * Gets the temporary directory.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @return string The temporary directory.
 	 */
@@ -185,7 +224,7 @@ class Release extends Command {
 	/**
 	 * Sets the plugin slug.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 */
 	protected function set_plugin_slug( string $plugin_slug ): void {
 		$this->plugin_slug = $plugin_slug;
@@ -194,7 +233,7 @@ class Release extends Command {
 	/**
 	 * Gets the plugin slug.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @return string The plugin slug.
 	 */
@@ -205,7 +244,7 @@ class Release extends Command {
 	/**
 	 *
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 */
 	protected function set_tag( string $tag ): void {
 		$this->tag = $tag;
@@ -214,7 +253,7 @@ class Release extends Command {
 	/**
 	 * Gets the destination tag.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @return string The destination tag.
 	 */
@@ -225,7 +264,7 @@ class Release extends Command {
 	/**
 	 * Gets the URL for the plugin on WordPress.org.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @return string The URL for the plugin on WordPress.org.
 	 */
@@ -236,7 +275,7 @@ class Release extends Command {
 	/**
 	 * Executes the command.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ) {
 		$this->set_input( $input );
@@ -255,7 +294,7 @@ class Release extends Command {
 		$this->set_plugin_slug( $plugin );
 
 		$local_repo = "{$temp_dir}/repo";
-		$svn_url    = self::WP_ORG_URL . $plugin;
+		$svn_url    = $this->get_svn_url();
 
 		// Log the arguments and options
 		$output->writeln( 'Plugin: ' . $plugin );
@@ -367,10 +406,10 @@ class Release extends Command {
 	}
 
 	/**
-	 * Compare two directories and return boolean depending if they are equal.
+	 * Compare two directories and return boolean depending on if they are equal.
 	 * It will check file paths and file sizes.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @param string $plugin_folder Directory A.
 	 * @param string $tag_folder    Directory B.
@@ -397,7 +436,7 @@ class Release extends Command {
 	/**
 	 * Cleanup the workspace and return error.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @param string|null $message
 	 *
@@ -414,7 +453,7 @@ class Release extends Command {
 	/**
 	 * Cleanup the workspace and return success.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @param string|null $message
 	 *
@@ -430,7 +469,7 @@ class Release extends Command {
 	/**
 	 * Cleanup the workspace.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 */
 	protected function cleanup() {
 		if ( $this->has_cleanup_step( 'remove_temp_dir' ) ) {
@@ -444,7 +483,7 @@ class Release extends Command {
 	/**
 	 * Catch CLI exit signals.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 */
 	protected function catch_cli_exit_signals(): void {
 		pcntl_signal( SIGTERM, [ $this, 'cli_signal_handler' ] );
@@ -454,7 +493,7 @@ class Release extends Command {
 	/**
 	 * Handle CLI exit signals.
 	 *
-	 * @since 1.2.9
+	 * @since 1.2.10
 	 *
 	 * @param mixed $signal
 	 */

--- a/src/Commands/SVN/Release.php
+++ b/src/Commands/SVN/Release.php
@@ -1,0 +1,471 @@
+<?php
+
+namespace TUT\Commands\SVN;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Release extends Command {
+	/**
+	 * Stores the input interface.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @var InputInterface|null
+	 */
+	protected ?InputInterface $input;
+
+	/**
+	 * Stores the output interface.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @var OutputInterface|null
+	 */
+	protected ?OutputInterface $output;
+
+	/**
+	 * Stores the command steps to cleanup.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @var array
+	 */
+	protected array $cleanup_steps = [];
+
+	/**
+	 * Stores the temporary directory to use.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @var string|null
+	 */
+	protected ?string $temp_dir;
+
+	/**
+	 * Stores the plugin slug.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @var string|null
+	 */
+	protected ?string $plugin_slug;
+
+	/**
+	 * Stores the destination tag.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @var string|null
+	 */
+	protected ?string $tag;
+
+	/**
+	 * @since 1.2.9
+	 *
+	 * @var int The exit code to use when the command succeeds.
+	 */
+	protected const CMD_SUCCESS = 0;
+
+	/**
+	 * @since 1.2.9
+	 *
+	 * @var int The exit code to use when the command fails.
+	 */
+	protected const CMD_FAILURE = 1;
+
+	/**
+	 * @since 1.2.9
+	 *
+	 * @var string Store the base URL for the WordPress.org SVN repository.
+	 */
+	protected const WP_ORG_URL = 'https://plugins.svn.wordpress.org/';
+
+	/**
+	 * Configures the command.
+	 *
+	 * @since 1.2.9
+	 */
+	protected function configure() {
+		$temp_dir = '/tmp/svn-tag/';
+
+		$this
+			->setName( 'svn:release' )
+			->setDescription( 'Changes the SVN trunk readme.txt Stable Tag of a Plugin.' )
+			->setHelp( 'This command allows you to update what is the Stable Tag version of a WP.org plugin.' )
+			->addArgument( 'plugin', InputArgument::REQUIRED, 'The slug of the Plugin on WordPress.org.' )
+			->addArgument( 'tag', InputArgument::REQUIRED, 'The SVN tag to be released.' )
+			->addOption( 'checksum_zip', 'c', InputOption::VALUE_OPTIONAL, 'The URL of the ZIP file in case you want to do a Checksum.' )
+			->addOption( 'temp_dir', 't', InputOption::VALUE_OPTIONAL, 'The temporary directory to use.', $temp_dir );
+	}
+
+	protected function has_cleanup_step( string $step ): bool {
+		return in_array( $step, $this->get_cleanup_steps(), true );
+	}
+
+	protected function get_cleanup_steps(): array {
+		return $this->cleanup_steps;
+	}
+
+	protected function include_cleanup_step( string $step ): void {
+		$allowed_steps = [
+			'remove_temp_dir',
+		];
+
+		if ( ! in_array( $step, $allowed_steps, true ) ) {
+			return;
+		}
+
+		$this->cleanup_steps[] = $step;
+	}
+
+	/**
+	 * Gets the input interface.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @return InputInterface The input interface.
+	 */
+	protected function get_input(): InputInterface {
+		return $this->input;
+	}
+
+	/**
+	 * Sets the input interface.
+	 *
+	 * @since 1.2.9
+	 */
+	protected function set_input( InputInterface $input ): void {
+		$this->input = $input;
+	}
+
+	/**
+	 * Sets the output interface.
+	 *
+	 * @since 1.2.9
+	 */
+	protected function set_output( OutputInterface $output ): void {
+		$this->output = $output;
+	}
+
+	/**
+	 * Gets the output interface.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @return OutputInterface The output interface.
+	 */
+	protected function get_output(): OutputInterface {
+		return $this->output;
+	}
+
+	/**
+	 * Sets the temporary directory.
+	 *
+	 * @since 1.2.9
+	 */
+	protected function set_temp_dir( string $dir ): void {
+		$this->temp_dir = $dir;
+	}
+
+	/**
+	 * Gets the temporary directory.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @return string The temporary directory.
+	 */
+	protected function get_temp_dir(): string {
+		return $this->temp_dir;
+	}
+
+	/**
+	 * Sets the plugin slug.
+	 *
+	 * @since 1.2.9
+	 */
+	protected function set_plugin_slug( string $plugin_slug ): void {
+		$this->plugin_slug = $plugin_slug;
+	}
+
+	/**
+	 * Gets the plugin slug.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @return string The plugin slug.
+	 */
+	protected function get_plugin_slug(): string {
+		return $this->plugin_slug;
+	}
+
+	/**
+	 *
+	 *
+	 * @since 1.2.9
+	 */
+	protected function set_tag( string $tag ): void {
+		$this->tag = $tag;
+	}
+
+	/**
+	 * Gets the destination tag.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @return string The destination tag.
+	 */
+	protected function get_tag(): string {
+		return $this->tag;
+	}
+
+	/**
+	 * Gets the URL for the plugin on WordPress.org.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @return string The URL for the plugin on WordPress.org.
+	 */
+	protected function get_svn_url(): string {
+		return self::WP_ORG_URL . $this->get_plugin_slug();
+	}
+
+	/**
+	 * Executes the command.
+	 *
+	 * @since 1.2.9
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ) {
+		$this->set_input( $input );
+		$this->set_output( $output );
+
+		$id               = date( 'Y-m-d-H-m-s' ) . '-' . substr( uniqid(), 0, 12 );
+		$plugin           = $input->getArgument( 'plugin' );
+		$tag              = $input->getArgument( 'tag' );
+		$checksum_zip_url = $input->getOption( 'checksum_zip' );
+		$temp_dir         = $input->getOption( 'temp_dir' );
+
+		$temp_dir = rtrim( $temp_dir, '/' ) . "/tag-{$id}";
+
+		$this->set_temp_dir( $temp_dir );
+		$this->set_tag( $tag );
+		$this->set_plugin_slug( $plugin );
+
+		$local_repo = "{$temp_dir}/repo";
+		$svn_url    = self::WP_ORG_URL . $plugin;
+
+		// Log the arguments and options
+		$output->writeln( 'Plugin: ' . $plugin );
+		$output->writeln( 'SVN URL: ' . $svn_url );
+		$output->writeln( 'Tag: ' . $tag );
+		if ( empty( $checksum_zip_url ) ) {
+			$output->writeln( 'Checksum ZIP URL: ' . $checksum_zip_url );
+		}
+		$output->writeln( 'Temporary Directory: ' . $temp_dir );
+
+		$plugin_dir = $temp_dir . '/plugin/';
+
+		if ( file_exists( $temp_dir ) ) {
+			$output->writeln( 'Temporary directory already exists: ' . $temp_dir );
+			shell_exec( "rm -rf {$temp_dir}" );
+
+			if ( file_exists( $temp_dir ) ) {
+				return $this->cleanup_to_error( "Couldn't cleanup the temporary directory, aborting." );
+			}
+		}
+
+		$output->writeln( 'Creating temporary working directory: ' . $temp_dir );
+		mkdir( $temp_dir, 0755, true );
+
+		if ( ! file_exists( $temp_dir ) ) {
+			return $this->cleanup_to_error( "Couldn't create the temporary directory, aborting." );
+		}
+
+		// From this moment forward we need to cleanup, so we catch an interrupt signal.
+		$this->catch_cli_exit_signals();
+		$this->include_cleanup_step( 'remove_temp_dir' );
+
+		$cd_to_repo_cmd = "cd {$local_repo} && ";
+
+		if ( ! empty( $checksum_zip_url ) ) {
+			// If the plugin extraction dir exists, delete it and recreate it.
+			if ( file_exists( $plugin_dir ) ) {
+				$output->writeln( 'Plugin storage directory already exists: ' . $plugin_dir );
+				shell_exec( "rm -rf {$plugin_dir}" );
+
+				if ( file_exists( $plugin_dir ) ) {
+					return $this->cleanup_to_error( "Couldn't cleanup the plugin storage directory, aborting." );
+				}
+			}
+
+			// Download and extract ZIP file to temporary directory
+			$zip_file = rtrim( $temp_dir, '/' ) . '/plugin.zip';
+
+			// just to make sure we can download the new file.
+			if ( file_exists( $zip_file ) && is_file( $zip_file ) ) {
+				unlink( $zip_file );
+				if ( file_exists( $zip_file ) ) {
+					return $this->cleanup_to_error( "Couldn't delete the existing zip, aborting." );
+				}
+			}
+
+			$output->writeln( 'Downloading ZIP file to: ' . $zip_file );
+
+			file_put_contents( $zip_file, file_get_contents( $checksum_zip_url ) );
+			$output->writeln( 'Extracting ZIP file to: ' . $temp_dir );
+			$zip = new \ZipArchive();
+
+			if ( $zip->open( $zip_file ) === true ) {
+				$zip->extractTo( $temp_dir );
+				$zip->close();
+
+				shell_exec( "mv {$temp_dir}/{$plugin} $plugin_dir" );
+				if ( ! file_exists( $plugin_dir ) ) {
+					return $this->cleanup_to_error( "ZIP was not extracted correctly, expected destination: {$plugin_dir}." );
+				}
+			} else {
+				return $this->cleanup_to_error( "Failed to open ZIP file." );
+			}
+
+			$clone_cmd = "svn co {$svn_url} {$local_repo} --depth=immediates";
+			$output->writeln( "Executing SVN Command: \n" . $clone_cmd );
+			shell_exec( $clone_cmd );
+
+			$update_tag_trunk_cmd = "svn update tags/{$tag}";
+			$output->writeln( "Executing SVN Command: \n" . $update_tag_trunk_cmd );
+			shell_exec( $cd_to_repo_cmd . $update_tag_trunk_cmd );
+
+			// Compare tag folder and extracted folder.
+			$tag_folder = "{$local_repo}/tags/{$tag}";
+
+			if ( ! file_exists( $tag_folder ) || ! is_dir( $tag_folder ) ) {
+				return $this->cleanup_to_error( "The tag was not downloaded properly, aborting." );
+			}
+
+			$scan = $this->check_folder_checksum( $plugin_dir, $tag_folder );
+
+			$output->writeln( "Comparing Directories:" );
+			$output->writeln( " - $plugin_dir" );
+			$output->writeln( " - $tag_folder" );
+
+			if ( ! $scan ) {
+				return $this->cleanup_to_error( "Failed the Checksum of the two folders." );
+			}
+		}
+
+		$output->writeln( '' );
+
+		// Copy SVN tag readme into trunk.
+		$copy_cmd = "svn copy {$svn_url}/tags/{$tag}/readme.txt {$svn_url}/trunk/readme.txt -m 'Copying {$tag} readme.txt into Trunk.'";
+		$output->writeln( "Executing SVN Command:  \n" . $copy_cmd );
+		shell_exec( $copy_cmd );
+
+		return $this->cleanup_to_success( "Operation completed successfully." );
+	}
+
+	/**
+	 * Compare two directories and return boolean depending if they are equal.
+	 * It will check file paths and file sizes.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @param string $plugin_folder Directory A.
+	 * @param string $tag_folder    Directory B.
+	 *
+	 * @return bool
+	 */
+	protected function check_folder_checksum( $plugin_folder, $tag_folder ): bool {
+		// Check if directories exist
+		if ( ! is_dir( $plugin_folder ) || ! is_dir( $tag_folder ) ) {
+			return false;
+		}
+
+		// Execute rsync command to check for added files.
+		$command = "cd {$plugin_folder} && find . -type f -exec stat -f \"%N|%z\" {} \; | sort";
+		exec( $command, $plugin_files );
+
+		// Execute rsync command to check for added files.
+		$command = "cd {$tag_folder} && find . -type f -exec stat -f \"%N|%z\" {} \; | sort";
+		exec( $command, $tag_files );
+
+		return md5( serialize( $tag_files ) ) === md5( serialize( $plugin_files ) );
+	}
+
+	/**
+	 * Cleanup the workspace and return error.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @param string|null $message
+	 *
+	 * @return int
+	 */
+	protected function cleanup_to_error( string $message = null ): int {
+
+		$this->cleanup();
+
+		$this->get_output()->writeln( $message );
+		return self::CMD_FAILURE;
+	}
+
+	/**
+	 * Cleanup the workspace and return success.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @param string|null $message
+	 *
+	 * @return int
+	 */
+	protected function cleanup_to_success( string $message = null ): int {
+		$this->cleanup();
+
+		$this->get_output()->writeln( $message );
+		return self::CMD_SUCCESS;
+	}
+
+	/**
+	 * Cleanup the workspace.
+	 *
+	 * @since 1.2.9
+	 */
+	protected function cleanup() {
+		if ( $this->has_cleanup_step( 'remove_temp_dir' ) ) {
+			$temp_dir = $this->get_temp_dir();
+
+			$this->get_output()->writeln( 'Deleting temporary files to cleanup workspace.' );
+			shell_exec( "rm -rf {$temp_dir}" );
+		}
+	}
+
+	/**
+	 * Catch CLI exit signals.
+	 *
+	 * @since 1.2.9
+	 */
+	protected function catch_cli_exit_signals(): void {
+		pcntl_signal( SIGTERM, [ $this, 'cli_signal_handler' ] );
+		pcntl_signal( SIGINT, [ $this, 'cli_signal_handler' ] );
+	}
+
+	/**
+	 * Handle CLI exit signals.
+	 *
+	 * @since 1.2.9
+	 *
+	 * @param mixed $signal
+	 */
+	public function cli_signal_handler( $signal ) {
+		switch ( $signal ) {
+			case SIGTERM:
+			case SIGKILL:
+			case SIGINT:
+				$this->get_output()->writeln( "User interrupted the command, cleaning up required, please wait." );
+				$this->cleanup();
+				exit;
+		}
+	}
+}

--- a/src/Commands/SVN/Tag.php
+++ b/src/Commands/SVN/Tag.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TUT\Commands;
+namespace TUT\Commands\SVN;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SvnTag extends Command {
+class Tag extends Command {
 	/**
 	 * Stores the input interface.
 	 *

--- a/tut
+++ b/tut
@@ -4,7 +4,7 @@
 require dirname( __FILE__ ) . '/vendor/autoload.php';
 
 define( '__TUT_DIR__', __DIR__ );
-define( 'TUT_VERSION', '1.2.8' );
+define( 'TUT_VERSION', '1.2.9' );
 
 use Symfony\Component\Console\Application;
 use TUT\Commands;
@@ -57,6 +57,7 @@ $application->add( new Commands\Sync );
 $application->add( new Commands\TBD );
 $application->add( new Commands\Version );
 $application->add( new Commands\Upgrade );
-$application->add( new Commands\SvnTag );
+$application->add( new Commands\SVN\Tag );
+$application->add( new Commands\SVN\Release );
 
 $application->run();


### PR DESCRIPTION
Still testing this particular command, but it gives us the power to release a given tag directly on WP.org and execute a  checksum on the tag we are planning on release.

---

Still missing, it needs to push one small change to the `.pot` file and the main PHP file, to trigger regenerating the GlotPress variables.