### PR TITLE
Add a delay to the processing of translations connections to prevent a .org lockout.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,10 @@
     "psr-4": {
       "TUT\\" : "src/"
     }
+  },
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": true
+    }
   }
 }

--- a/src/Commands/I18n/GlotPress.php
+++ b/src/Commands/I18n/GlotPress.php
@@ -146,7 +146,7 @@ class GlotPress extends Command {
 				continue;
 			}
 
-			// Skip any translation set that doest match our min translated.
+			// Skip any translation set that does't match our min translated.
 			if ( $options->filter->minimum_percentage > $translation->percent_translated ) {
 				continue;
 			}
@@ -160,9 +160,18 @@ class GlotPress extends Command {
 			}
 		}
 
-		array_map( static function( $promise ) {
-			$promise->wait();
-		}, $promises );
+		$connections = 0;
+
+		array_map(
+			static function( $promise ) use ( $connections ) {
+				$connections++;
+				$wait = ( 0 === $connections % 4 ) ? 250 : 50;
+				// Add some delay to prevent sever lockout
+				usleep( $wait );
+				$promise->wait();
+			},
+			$promises
+		);
 	}
 
 	protected function download_and_save_translation( $plugin, $options, $translation, $format, $project_url, $tried = 0 ) {

--- a/src/Commands/I18n/GlotPress.php
+++ b/src/Commands/I18n/GlotPress.php
@@ -100,6 +100,7 @@ class GlotPress extends Command {
 			// cd into the plugin directory
 			chdir( $plugin_dir );
 
+			// @todo: were we expecting to do something with this?
 			$this->has_common = file_exists( 'common' );
 
 			$this->download_language_files( $plugin );
@@ -173,7 +174,7 @@ class GlotPress extends Command {
 		array_map(
 			static function( $promise ) use ( $connections ) {
 				$connections++;
-				$wait = ( 0 === $connections % 4 ) ? 250 : 50;
+				$wait = ( 0 === $connections % 4 ) ? 250000 : 50000;
 				// Add some delay to prevent sever lockout
 				usleep( $wait );
 				$promise->wait();

--- a/src/Commands/I18n/GlotPress.php
+++ b/src/Commands/I18n/GlotPress.php
@@ -12,12 +12,12 @@ use GuzzleHttp\Client;
 
 class GlotPress extends Command {
 	/**
-	 * @var string The branch in which the version is being prepared
+	 * @var string The branch in which the version is being prepared.
 	 */
 	protected $branch;
 
 	/**
-	 * @var bool Has a common/ directory
+	 * @var bool Has a common/ directory. Unused.
 	 */
 	private $has_common = false;
 
@@ -68,6 +68,9 @@ class GlotPress extends Command {
 		return file_exists( 'package.json' );
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	protected function configure() {
 		parent::configure();
 
@@ -78,6 +81,9 @@ class GlotPress extends Command {
 
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	protected function execute( InputInterface $input, OutputInterface $output ) {
 		$this->retries = (int) $this->retries ?: $input->getOption( 'retries' );
 
@@ -108,7 +114,9 @@ class GlotPress extends Command {
 	}
 
 	/**
-	 * Runs build commands in parallel
+	 * Runs build commands in parallel.
+	 *
+	 * @param object $plugin Plugin object.
 	 */
 	private function download_language_files( $plugin ) {
 		$package = $this->get_plugin_package_data();
@@ -141,12 +149,12 @@ class GlotPress extends Command {
 		$promises = [];
 
 		foreach ( $project_data->translation_sets as $translation ) {
-			// skip when translations are zero.
+			// Skip when translations are zero.
 			if ( 0 === $translation->current_count ) {
 				continue;
 			}
 
-			// Skip any translation set that does't match our min translated.
+			// Skip any translation set that doesn't match our min % translated.
 			if ( $options->filter->minimum_percentage > $translation->percent_translated ) {
 				continue;
 			}
@@ -174,6 +182,18 @@ class GlotPress extends Command {
 		);
 	}
 
+	/**
+	 * Downloads and saves a translation file from the .org translation API.
+	 *
+	 * @param object $plugin      Unused plugin object.
+	 * @param object $options     Option object
+	 * @param object $translation Translation object.
+	 * @param string $format      File format.
+	 * @param string $project_url Project URL.
+	 * @param int    $tried       How many times we tried to download this file.
+	 *
+	 * @return null|\GuzzleHttp\Promise\PromiseInterface $promise The promise for later consumption
+	 */
 	protected function download_and_save_translation( $plugin, $options, $translation, $format, $project_url, $tried = 0 ) {
 		$translation_url = "{$project_url}/{$translation->locale}/{$translation->slug}/export-translations?format={$format}";
 		if ( $tried >= $this->retries ) {
@@ -209,7 +229,7 @@ class GlotPress extends Command {
 			if ( 200 > $translation_size ) {
 				$this->output->writeln( "<fg=red>Failed to fetch translation from {$translation_url}</>", OutputInterface::VERBOSITY_VERBOSE );
 
-				// Not sure if 2seconds is needed, but it prevents they firewall from catching us.
+				// Not sure if 2 seconds is needed, but it prevents the firewall from catching us.
 				sleep( 2 );
 
 				// Retries to download this file.


### PR DESCRIPTION
We hit the lockout with TEC as there are so many `.mo` files. Rapidly requesting all of them (as an anonymous user) at once results in the sever suspecting DDOS and locking us down.

The result is the script gives us back empty files (where the content was not returned)

This adds a slight delay to each request and a longer one every 4 requests to help prevent that issue.