### PR TITLE
fix: remove no longer existent plugins

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.12] - 2026-02-06
+
+- Remove deprecated plugins from the default `tut.json` and `tut.local-sample.json` files.
+
 ## [1.2.11] - 2023-12-14
 
 - Fix: Add some delay to the translation requests to avoid a .org lock-out.

--- a/tut
+++ b/tut
@@ -4,7 +4,7 @@
 require dirname( __FILE__ ) . '/vendor/autoload.php';
 
 define( '__TUT_DIR__', __DIR__ );
-define( 'TUT_VERSION', '1.2.11' );
+define( 'TUT_VERSION', '1.2.12' );
 
 use Symfony\Component\Console\Application;
 use TUT\Commands;

--- a/tut.json
+++ b/tut.json
@@ -55,17 +55,6 @@
 			"submodulesync" : true
 		},
 		{
-			"repo"      : "the-events-calendar/events-community-tickets",
-			"name"      : "events-community-tickets",
-			"bootstrap" : "events-community-tickets.php",
-			"main"      : "src/Tribe/Main.php",
-			"version"   : "VERSION",
-			"alias"     : [ "ect", "community-tickets", "ct", "the-events-calendar-community-events-tickets" ],
-			"has_readme": true,
-			"free"      : false,
-			"submodulesync" : true
-		},
-		{
 			"repo"      : "the-events-calendar/events-eventbrite",
 			"name"      : "events-eventbrite",
 			"bootstrap" : "tribe-eventbrite.php",
@@ -121,28 +110,6 @@
 			"submodulesync" : true
 		},
 		{
-			"repo"      : "the-events-calendar/events-virtual",
-			"name"      : "events-virtual",
-			"bootstrap" : "events-virtual.php",
-			"main"      : "src/Tribe/Plugin_Register.php",
-			"version"   : "VERSION",
-			"alias"     : [ "ve", "ev" ],
-			"has_readme": true,
-			"free"      : false,
-			"submodulesync" : true
-		},
-		{
-			"repo"      : "the-events-calendar/event-automator",
-			"name"      : "event-automator",
-			"bootstrap" : "event-automator.php",
-			"main"      : "src/Event_Automator/Plugin.php",
-			"version"   : "VERSION",
-			"alias"     : [ "events-automator", "automator", "auto", "eva" ],
-			"has_readme": true,
-			"free"      : false,
-			"submodulesync" : true
-		},
-		{
 			"repo"      : "stellarwp/restrict-content-pro",
 			"name"      : "restrict-content-pro",
 			"bootstrap" : "restrict-content-pro.php",
@@ -164,16 +131,6 @@
 			"alias"     : [ "ld", "sfwd-lms", "learndash" ],
 			"has_readme": false,
 			"free"      : false
-		},
-		{
-			"repo"      : "the-events-calendar/events-elasticsearch",
-			"name"      : "events-elasticsearch",
-			"bootstrap" : "events-elasticsearch.php",
-			"main"      : "src/Tribe/Main.php",
-			"version"   : "const VERSION",
-			"alias"     : [ "elasticsearch", "es", "the-events-calendar-elasticsearch" ],
-			"has_readme": true,
-			"free"      : true
 		},
 		{
 			"repo"      : "the-events-calendar/advanced-post-manager",
@@ -224,27 +181,6 @@
 			"alias"     : [ "give" ],
 			"has_readme": true,
 			"free"      : true
-		},
-		{
-			"repo"      : "the-events-calendar/loxi-event-calendar",
-			"name"      : "loxi-event-calendar",
-			"bootstrap" : "loxi-event-calendar.php",
-			"main"      : "src/Tribe/Main.php",
-			"version"   : "const VERSION",
-			"alias"     : [ "lec", "loxi-plugin" ],
-			"has_readme": true,
-			"free"      : true
-		},
-		{
-			"repo"          : "the-events-calendar/event-tickets-wallet-plus",
-			"name"          : "event-tickets-wallet-plus",
-			"bootstrap"     : "event-tickets-wallet-plus.php",
-			"main"          : "src/Tickets_Wallet_Plus/Plugin_Register.php",
-			"version"       : "VERSION",
-			"alias"         : [ "wallet+", "wallet-plus", "etwp", "etwplus", "etw+", "event-tickets-wallet", "event-tickets-wallet-plus" ],
-			"has_readme"    : true,
-			"free"          : false,
-			"submodulesync" : true
 		},
 		{
 			"repo"          : "stellarwp/event-schedule-manager",

--- a/tut.local-sample.json
+++ b/tut.local-sample.json
@@ -17,14 +17,6 @@
 			"free"      : false
 		},
 		{
-			"name"      : "events-community-tickets",
-			"bootstrap" : "events-community-tickets.php",
-			"main"      : "src/Tribe/Main.php",
-			"version"   : "VERSION",
-			"alias"     : [ "ect", "community-tickets", "ct", "the-events-calendar-community-events-tickets" ],
-			"free"      : false
-		},
-		{
 			"name"      : "events-eventbrite",
 			"bootstrap" : "tribe-eventbrite.php",
 			"main"      : "src/Tribe/Main.php",
@@ -65,22 +57,6 @@
 			"free"      : false
 		},
 		{
-			"name"      : "events-virtual",
-			"bootstrap" : "events-virtual.php",
-			"main"      : "src/Tribe/Plugin.php",
-			"version"   : "VERSION",
-			"alias"     : [ "ve", "ev" ],
-			"free"      : true
-		},
-		{
-			"name"      : "events-elasticsearch",
-			"bootstrap" : "events-elasticsearch.php",
-			"main"      : "src/Tribe/Main.php",
-			"version"   : "const VERSION",
-			"alias"     : [ "elasticsearch", "es", "the-events-calendar-elasticsearch" ],
-			"free"      : true
-		},
-		{
 			"name"      : "advanced-post-manager",
 			"bootstrap" : "tribe-apm.php",
 			"main"      : "tribe-apm.php",
@@ -118,14 +94,6 @@
 			"main"      : "gigpress.php",
 			"version"   : "define('GIGPRESS_VERSION')",
 			"alias"     : [ "gig" ],
-			"free"      : true
-		},
-		{
-			"name"      : "loxi-event-calendar",
-			"bootstrap" : "loxi-event-calendar.php",
-			"main"      : "src/Tribe/Main.php",
-			"version"   : "const VERSION",
-			"alias"     : [ "lec", "loxi-plugin" ],
 			"free"      : true
 		}
 	]


### PR DESCRIPTION
Removes no longer existent wp plugins.

This would result in the `submodule-sync` command to fail because of the attempt to check on repos that would no longer exists: [example](https://github.com/the-events-calendar/tribe-common/actions/runs/21726408176/job/62669491509?pr=2867)